### PR TITLE
Update global `$Adminer` -> `adminer()`.

### DIFF
--- a/plugins/AdminerSimpleMenu.php
+++ b/plugins/AdminerSimpleMenu.php
@@ -46,7 +46,7 @@ class AdminerSimpleMenu
         $actions = [$_GET["select"], $_GET["edit"], $_GET["table"], $_GET["create"], $_GET["indexes"], $_GET["foreign"], $_GET["trigger"]];
 
         foreach ($tables as $table => $status) {
-            $name = Adminer::tableName($status);
+            $name = adminer()->tableName($status);
             if ($name == "") {
                 continue;
             }


### PR DESCRIPTION
FIX: Uncaught Error: Non-static method Adminer::tableName() cannot be called statically in /var/www/html/plugins/AdminerSimpleMenu.php:49